### PR TITLE
do not require CSS in Node context

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,7 @@
-require 'react-lite-coder/src/index.less'
-require 'react-lite-misc/src/index.less'
-require 'teambition-icon-fonts/css/teambition-ui-icons.css'
+if typeof window isnt 'undefined'
+  require 'react-lite-coder/src/index.less'
+  require 'react-lite-misc/src/index.less'
+  require 'teambition-icon-fonts/css/teambition-ui-icons.css'
 
 exports.File = require './default/file'
 exports.Image = require './default/image'


### PR DESCRIPTION
这里合并以后, 需要注意更新 lite-coder 版本, 旧版本的 lite-coder 里存在 CSS 引用.
